### PR TITLE
Use partial draw for CPU animation

### DIFF
--- a/firmware/src/gfx.rs
+++ b/firmware/src/gfx.rs
@@ -141,6 +141,10 @@ where
         NIGHT_COLORS
     };
 
+    let background = PrimitiveStyleBuilder::new()
+        .fill_color(colors.background)
+        .build();
+
     let cpu_peak_bar_style = PrimitiveStyleBuilder::new()
         .fill_color(colors.cpu_bar_peak)
         .build();
@@ -149,22 +153,15 @@ where
         .fill_color(colors.cpu_bar_avg)
         .build();
 
-    // Draw longer peak core load bar.
-    bar_graph(
-        display,
-        cpu_peak_bar_style,
-        Point::new(DISP_X_PAD, line_y_offset(1)),
-        Size::new(BAR_WIDTH, BAR_HEIGHT),
-        perf.peak_core_load,
-    )?;
-
-    // Draw shorter, overlapping all cores load bar.
-    bar_graph(
+    double_bar_graph(
         display,
         cpu_avg_bar_style,
+        cpu_peak_bar_style,
+        background,
         Point::new(DISP_X_PAD, line_y_offset(1)),
         Size::new(BAR_WIDTH, BAR_HEIGHT),
         perf.all_cores_load,
+        perf.peak_core_load,
     )?;
 
     Ok(())
@@ -204,11 +201,60 @@ where
     };
 
     // Wide, high value bar.
+    Rectangle::new(offset, Size::new(scale_x(val), size.height))
+        .into_styled(style)
+        .draw(display)?;
+
+    Ok(())
+}
+
+// Draws overlaid bar graph, where left_val is always smaller than right_val.
+fn double_bar_graph<T>(
+    display: &mut T,
+    left_style: PrimitiveStyle<Rgb565>,
+    right_style: PrimitiveStyle<Rgb565>,
+    background: PrimitiveStyle<Rgb565>,
+    offset: Point,
+    size: Size,
+    left_val: f32,
+    right_val: f32,
+) -> Result<(), T::Error>
+where
+    T: DrawTarget<Color = Rgb565>,
+{
+    // Scale float values into integer pixel widths.
+    let max_x = size.width - 1;
+    let max_x_f = max_x as f32;
+    let scale_x = |val: f32| {
+        let x = (max_x_f * val) as u32;
+        x.min(max_x)
+    };
+    let left_scaled = scale_x(left_val);
+    let right_scaled = scale_x(right_val);
+
+    if left_scaled != 0 {
+        Rectangle::new(offset, Size::new(left_scaled, size.height))
+            .into_styled(left_style)
+            .draw(display)?;
+    }
+
+    let mut max_scaled = left_scaled;
+    if right_scaled > left_scaled {
+        max_scaled = right_scaled;
+        Rectangle::new(
+            Point::new(left_scaled as i32, 0) + offset,
+            Size::new(right_scaled - left_scaled, size.height),
+        )
+        .into_styled(right_style)
+        .draw(display)?;
+    }
+
+    // Clear remaining space.
     Rectangle::new(
-        Point::new(0, 0) + offset,
-        Size::new(scale_x(val), size.height),
+        Point::new(max_scaled as i32, 0) + offset,
+        Size::new(size.width - max_scaled, size.height),
     )
-    .into_styled(style)
+    .into_styled(background)
     .draw(display)?;
 
     Ok(())

--- a/firmware/src/gfx.rs
+++ b/firmware/src/gfx.rs
@@ -78,14 +78,6 @@ where
         .text_color(colors.cpu_text)
         .build();
 
-    let cpu_peak_bar_style = PrimitiveStyleBuilder::new()
-        .fill_color(colors.cpu_bar_peak)
-        .build();
-
-    let cpu_avg_bar_style = PrimitiveStyleBuilder::new()
-        .fill_color(colors.cpu_bar_avg)
-        .build();
-
     let mem_text_style = MonoTextStyleBuilder::new()
         .font(&FONT)
         .text_color(colors.mem_text)
@@ -111,23 +103,7 @@ where
     )
     .draw(display)?;
 
-    // Draw longer peak core load bar.
-    bar_graph(
-        display,
-        cpu_peak_bar_style,
-        Point::new(DISP_X_PAD, line_y_offset(1)),
-        Size::new(BAR_WIDTH, BAR_HEIGHT),
-        perf.peak_core_load,
-    )?;
-
-    // Draw shorter, overlapping all cores load bar.
-    bar_graph(
-        display,
-        cpu_avg_bar_style,
-        Point::new(DISP_X_PAD, line_y_offset(1)),
-        Size::new(BAR_WIDTH, BAR_HEIGHT),
-        perf.all_cores_load,
-    )?;
+    draw_cpu_bar_graph(display, perf)?;
 
     // RAM heading.
     Text::new("RAM", text_point(DISP_X_PAD, 2), mem_text_style).draw(display)?;
@@ -149,6 +125,46 @@ where
         Point::new(DISP_X_PAD, line_y_offset(3)),
         Size::new(BAR_WIDTH, BAR_HEIGHT),
         perf.memory_load,
+    )?;
+
+    Ok(())
+}
+
+// Renders the overlaid CPU bar graphs, can be used without clearing the screen first.
+pub fn draw_cpu_bar_graph<T>(display: &mut T, perf: &message::PerfData) -> Result<(), T::Error>
+where
+    T: DrawTarget<Color = Rgb565>,
+{
+    let colors = if perf.daytime {
+        DAY_COLORS
+    } else {
+        NIGHT_COLORS
+    };
+
+    let cpu_peak_bar_style = PrimitiveStyleBuilder::new()
+        .fill_color(colors.cpu_bar_peak)
+        .build();
+
+    let cpu_avg_bar_style = PrimitiveStyleBuilder::new()
+        .fill_color(colors.cpu_bar_avg)
+        .build();
+
+    // Draw longer peak core load bar.
+    bar_graph(
+        display,
+        cpu_peak_bar_style,
+        Point::new(DISP_X_PAD, line_y_offset(1)),
+        Size::new(BAR_WIDTH, BAR_HEIGHT),
+        perf.peak_core_load,
+    )?;
+
+    // Draw shorter, overlapping all cores load bar.
+    bar_graph(
+        display,
+        cpu_avg_bar_style,
+        Point::new(DISP_X_PAD, line_y_offset(1)),
+        Size::new(BAR_WIDTH, BAR_HEIGHT),
+        perf.all_cores_load,
     )?;
 
     Ok(())

--- a/firmware/src/perf.rs
+++ b/firmware/src/perf.rs
@@ -3,7 +3,7 @@ use heapless::Deque;
 use shared::message::PerfData;
 
 // Frames per second for interpolated display updates.
-const FRAMES_PER_SECOND: u32 = 7;
+const FRAMES_PER_SECOND: u32 = 18;
 
 // CPU bar fall-off rate in percentage points per second.
 const FALL_PCT_PER_SECOND: f32 = 70.0;

--- a/firmware/src/perf.rs
+++ b/firmware/src/perf.rs
@@ -13,8 +13,15 @@ pub const FRAME_MS: u64 = 1000 / FRAMES_PER_SECOND as u64;
 
 const FALL_FRAC_PER_FRAME: f32 = FALL_PCT_PER_SECOND / 100.0 / FRAMES_PER_SECOND as f32;
 
+pub enum PerfFrame {
+    // Complete frame should redraw the entire screen.
+    Complete(PerfData),
+    // Partial frame only updates CPU graphs.
+    Partial(PerfData),
+}
+
 // Frames of perf data queued for display.
-pub type FramesDeque = Deque<PerfData, 64>;
+pub type FramesDeque = Deque<PerfFrame, 64>;
 
 /// Calculates what to display based on the previously stored state and new target state,
 /// if present.
@@ -29,7 +36,7 @@ pub fn update_state(
     match previous {
         // Displays new perf packet unaltered, as there is no history.
         None => {
-            frames.push_back(target).ok();
+            frames.push_back(PerfFrame::Complete(target)).ok();
             Some(target)
         }
 
@@ -48,7 +55,7 @@ pub fn update_state(
             // Generate upcoming frames. Does not schedule frame at 1s, as that
             // is when the next PerfData packet should arrive from the host.
             let mut prev = prev;
-            for _ in 0..FRAMES_PER_SECOND {
+            for i in 0..FRAMES_PER_SECOND {
                 // Calculate perf data for this frame, store in prev for basis of next frame.
                 prev = PerfData {
                     all_cores_load: update_cpu_load(prev.all_cores_load, target.all_cores_load),
@@ -58,7 +65,14 @@ pub fn update_state(
                     daytime: target.daytime,
                 };
 
-                if frames.push_back(prev).is_err() {
+                let frame = if i == 0 {
+                    PerfFrame::Complete(prev)
+                } else {
+                    // Only paint CPU bar graphs.
+                    PerfFrame::Partial(prev)
+                };
+
+                if frames.push_back(frame).is_err() {
                     error!("Frame queue is full");
                     break;
                 }


### PR DESCRIPTION
- Wrap perf frames to hold complete or partial updates
- draw double bar on the fly
- increase FPS
- reduce function arg count for clippy
