### PR TITLE
shared: add `defmt-log` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ to make it more visually appealing.
 
 A simple Linux daemon to send CPU info to the device.
 
+### Building
+
+Install rustup per your Linux distribution to get a functioning Rust toolchain.
+Use `cargo run` to test the daemon:
+
+```sh
+env RUST_LOG=debug cargo run
+```
+
 ## daemon/windows
 
 Windows service to send CPU info to the device.

--- a/firmware/Cargo.toml
+++ b/firmware/Cargo.toml
@@ -22,7 +22,7 @@ panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 postcard = "1.0.2"
 rtic-core = "1.0.0"
 rtic-monotonic = "1.0.0"
-shared = { path = "../shared" }
+shared = { path = "../shared", features = ["defmt-log"] }
 rp2040-boot2 = "0.2.1"
 rp2040-hal = { version = "0.6.0", features = ["rt", "rp2040-e5"] }
 rp2040-monotonic = "<=1.1.0"

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -12,6 +12,7 @@ Install build environment:
 
 ```sh
 rustup target add thumbv6m-none-eabi
+cargo install flip-link
 cargo install probe-run
 ```
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -7,5 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-defmt = "0.3.0"
+defmt = { version = "0.3", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+
+[features]
+# Enable defmt support, firmware only.
+defmt-log = ["dep:defmt"]

--- a/shared/src/message.rs
+++ b/shared/src/message.rs
@@ -1,13 +1,14 @@
-use defmt::Format;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Format, Serialize, Deserialize)]
+#[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum FromHost {
     ClearScreen,
     ShowPerf(PerfData),
 }
 
-#[derive(Clone, Copy, Debug, Format, Serialize, Deserialize)]
+#[cfg_attr(feature = "defmt-log", derive(defmt::Format))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct PerfData {
     // Aggregate load of all CPU cores, 0-1.0.
     pub all_cores_load: f32,


### PR DESCRIPTION
Make defmt's use optional in the shared library, to prevent link errors on non-MCU platforms.

Fixes #22 